### PR TITLE
Implement command history logging

### DIFF
--- a/headers/builtin.h
+++ b/headers/builtin.h
@@ -6,10 +6,11 @@
 int cmd_cd(char** args);
 int cmd_help(char** args);
 int cmd_exit(char** args);
+int cmd_history(char** args);
 
 void log_history(char** args);
 
-extern char* builtin_str[3];
+extern char* builtin_str[4];
 
 // array of function pointers (that can take in an array of strings, which are args, and returns an int)
 extern int (*builtin_func[])(char**);

--- a/headers/builtin.h
+++ b/headers/builtin.h
@@ -1,9 +1,13 @@
 #ifndef BUILTIN_H
 #define BUILTIN_H
 
+#define HISTORY_FILE ".namsh_history"
+
 int cmd_cd(char** args);
 int cmd_help(char** args);
 int cmd_exit(char** args);
+
+void log_history(char** args);
 
 extern char* builtin_str[3];
 

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -64,7 +64,28 @@ void log_history(char** args)
     char history_path[1024];
     snprintf(history_path, sizeof(history_path), "%s/%s", home_dir, HISTORY_FILE);
 
-    FILE* history_file = fopen(history_path, "a");
+    // open the file in read mode to get the last id
+    FILE* history_file = fopen(history_path, "r");
+    int last_id = 0;
+
+    if (history_file != NULL)
+    {
+        char line[1024];
+        while (fgets(line, sizeof(line), history_file) != NULL)
+        {
+            char* colon_pos = strchr(line, ':');
+
+            if (colon_pos != NULL)
+                last_id = atoi(line);
+        }
+        fclose(history_file);
+    }
+
+    // increment the id for the new command
+    int cmd_id = ++last_id;
+
+    // writing the command into the history file
+    history_file = fopen(history_path, "a");
     if (history_file == NULL)
         perror("namsh: Error opening history file");
 
@@ -76,7 +97,7 @@ void log_history(char** args)
         strcat(command, " ");
     }
 
-    fprintf(history_file, "%s\n", command);
+    fprintf(history_file, "%d:%s\n", cmd_id, command);
 
     fclose(history_file);
 }

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -5,16 +5,18 @@
 
 #include "../headers/builtin.h"
 
-char* builtin_str[3] = {
+char* builtin_str[4] = {
     "cd",
     "help",
-    "exit"
+    "exit",
+    "history"
 };
 
 int (*builtin_func[])(char**) = {
     &cmd_cd,
     &cmd_help,
-    &cmd_exit
+    &cmd_exit,
+    &cmd_history
 };
 
 int cmd_cd(char** args)
@@ -52,6 +54,30 @@ int cmd_help(char** args)
 int cmd_exit(char** args)
 {
     return 0;
+}
+
+int cmd_history(char** args)
+{
+    char* home_dir = getenv("HOME");
+
+    if (home_dir == NULL)
+        fprintf(stderr, "namsh: HOME environment variable not set");
+
+    char history_path[1024];
+    snprintf(history_path, sizeof(history_path), "%s/%s", home_dir, HISTORY_FILE);
+
+    FILE* history_file = fopen(history_path, "r");
+    if (history_file == NULL)
+        perror("namsh: Error opening history file");
+
+    char line_buffer[1024];
+    
+    while (fgets(line_buffer, sizeof(line_buffer), history_file) != NULL)
+        printf("%s", line_buffer);
+
+    fclose(history_file);
+
+    return 1;
 }
 
 void log_history(char** args)

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -53,3 +53,30 @@ int cmd_exit(char** args)
 {
     return 0;
 }
+
+void log_history(char** args)
+{
+    char* home_dir = getenv("HOME");
+
+    if (home_dir == NULL)
+        fprintf(stderr, "Error: HOME environment variable not set.\n");
+
+    char history_path[1024];
+    snprintf(history_path, sizeof(history_path), "%s/%s", home_dir, HISTORY_FILE);
+
+    FILE* history_file = fopen(history_path, "a");
+    if (history_file == NULL)
+        perror("namsh: Error opening history file");
+
+    // concatenate all arguments into a single command string
+    char command[1024] = "";
+    for (int i = 0; args[i] != NULL; i++)
+    {
+        strcat(command, args[i]);
+        strcat(command, " ");
+    }
+
+    fprintf(history_file, "%s\n", command);
+
+    fclose(history_file);
+}

--- a/src/parser.c
+++ b/src/parser.c
@@ -15,6 +15,8 @@ int launch_child_process(char** args)
 
     if (pid == 0) 
     {
+        log_history(args);
+
         // Child process
         if (execvp(args[0], args) == -1) // 1st one is the program name
         {
@@ -52,6 +54,7 @@ int execute_cmd(char** args)
     {
         if (strcmp(args[0], builtin_str[i]) == 0) 
         {
+            log_history(args);
             return (*builtin_func[i])(args); // calling the function
         }
     }


### PR DESCRIPTION
Add command history logging into a file called `.namsh_history` in the home directory. The shell will log the full command (along with the arguments and flags) and assigns an ID to the command.

Fixes #2 